### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Make sure you save classes to subdirectories like the file groups in Xcode to ke
 
 For transparency and insight into our release cycle, and for striving to maintain backward compatibility, Butter will be maintained according to the [Semantic Versioning](http://semver.org/) guidelines as much as possible.
 
-###Beta versions
+### Beta versions
 
 Beta releases will be numbered with the following format:
 
 `0.<major>.<minor>-<patch>`
 
-###Stable versions
+### Stable versions
 
 Releases will be numbered with the following format:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
